### PR TITLE
Support for Danfoss Thermostat Valve

### DIFF
--- a/dist/Devolo.js
+++ b/dist/Devolo.js
@@ -152,6 +152,11 @@ var Devolo = (function () {
                 else if (item.properties.deviceModelUID.indexOf('Thermostat:Valve') > -1) {
                     device = new DevoloDevice_1.ThermostatValveDevice();
                 }
+                //to support Danfoss Living Connect ThermostatValve Z v1.06 014G0013 that can't be identified by deviceModelUID: 'devolo.model.Unknown:Device',
+                //see http://products.z-wavealliance.org/products/1507/pics
+                else if (item.properties.prodID == '0x0004' && item.properties.prodTypeID == '0x0005'){
+                    device = new DevoloDevice_1.ThermostatValveDevice();
+                }
                 else if (item.properties.deviceModelUID.indexOf('Smoke:Detector') > -1) {
                     device = new DevoloDevice_1.SmokeDetectorDevice();
                 }


### PR DESCRIPTION
Danfoss Thermostat Valve is currently not supported since it does not identify as Thermostat over item.properties.deviceModelUID...made a proposed change to support the ThermostatValve. Maybe the DHC API offers more information to the device.
I only got these Object out
{ pendingOperations: null,
     batteryLow: false,
     zoneId: 'hz_1',
     isSecurelyIncluded: false,
     zone: 'Wohnzimmer',
     prodTypeID: '0x0005',
     statisticsUID: 'st.hdm:ZWave:F64850E3/6',
     secureInclusionCode: 0,
     prodID: '0x0004',
     status: 1,
     settingUIDs: [ 'gds.hdm:ZWave:F64850E3/6' ],
     manID: '0x0002',
     batteryLevel: 94,
     icon: 'icon_22',
     operationStatus: null,
     description: null,
     wrongDevicePaired: false,
     isOwn: true,
     deviceModelUID: 'devolo.model.Unknown:Device',
     itemName: 'heizung',
     elementUIDs: [ 'devolo.MultiLevelSwitch:hdm:ZWave:F64850E3/6' ] },